### PR TITLE
fix case in EAstdlib.event include

### DIFF
--- a/MMB Core.event
+++ b/MMB Core.event
@@ -1,5 +1,5 @@
 
-	#include "EAStdlib.event"
+	#include "EAstdlib.event"
 	#include "Extensions/Hack Installation.txt"
 
 	#include "Internal/UI1 Proc Code.event"


### PR DESCRIPTION
Case must match for non-windows build